### PR TITLE
Remove unused imports to fix Eclipse 2025-09 compatibility

### DIFF
--- a/org.emoflon.site.build/src/org/emoflon/sitexml/SiteXMLBuilderApp.java
+++ b/org.emoflon.site.build/src/org/emoflon/sitexml/SiteXMLBuilderApp.java
@@ -1,26 +1,15 @@
 package org.emoflon.sitexml;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 import org.eclipse.ant.core.AntCorePlugin;
 import org.eclipse.ant.internal.core.AntClassLoader;
-import org.eclipse.core.internal.jobs.InternalJob;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
-import org.eclipse.osgi.internal.framework.EquinoxBundle;
-import org.eclipse.osgi.internal.framework.EquinoxContainer;
-import org.eclipse.osgi.internal.loader.EquinoxClassLoader;
-import org.eclipse.osgi.internal.url.EquinoxFactoryManager;
-import org.eclipse.osgi.launch.Equinox;
 import org.eclipse.pde.internal.core.PDECore;
 import org.eclipse.pde.internal.core.exports.SiteBuildOperation;
 import org.eclipse.pde.internal.core.ifeature.IFeatureModel;


### PR DESCRIPTION
One of the `org.eclipse.osgi.internal` imports is not available in Eclipse 2025-09, and, hence, the project cannot be built with the latest Eclipse version. This PR removes the (unused) import and fixes the compilation problem.